### PR TITLE
Update CATCommands.cs

### DIFF
--- a/Project Files/Source/Console/CAT/CATCommands.cs
+++ b/Project Files/Source/Console/CAT/CATCommands.cs
@@ -2841,7 +2841,7 @@ namespace Thetis
             else if (radio == "ANAN10" || radio == "ANAN10E")
                 return "0";
 
-            else if (radio == "ANAN100" || radio == "ANAN100B" || radio == "ANAN100D" || radio == "ANAN200D" || radio == "ANAN8000D")
+            else if (radio == "ANAN100" || radio == "ANAN100B" || radio == "ANAN100D" || radio == "ANAN200D" || radio == "ANAN7000DLE" || radio == "ANAN8000D")
                 return "1";
             else
                 return parser.Error1;


### PR DESCRIPTION
missing Anan7000DLE added to ZZFM Radio List

I also noticed if Hermes is selected, output value is always 1 regardless if alex button is switched on or off.
If Alex is off, output should be 0. In PowerSDR it works like it should. 
Just wanted to mention it.

