### PR TITLE
Thetis-Installer: remove firewall install rule

### DIFF
--- a/Project Files/Source/Thetis-Installer/Product.wxs
+++ b/Project Files/Source/Thetis-Installer/Product.wxs
@@ -196,30 +196,13 @@
     </DirectoryRef>
        
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-      
       <Component Id="fwException" Guid="*" Transitive="yes">
-        <Condition>Privileged</Condition>
-        <File Id="ThetisEXE"
-              Source="$(var.FilesPath)Thetis.exe"
-              KeyPath="yes">
-          <fire:FirewallException Id="thetis_$(var.Platform)_tcp"
-                      Name="$(var.ThetisName) (TCP In)"
-                      Description="TCP In-bound Firewall rule for OpenHPSDR SDRs running Thetis"
-                      Protocol="tcp"
-                      Scope="any"
-                      IgnoreFailure="no"
-                      Profile="all" /> 
-        
-          <fire:FirewallException Id="thetis_$(var.Platform)_udp"
-                      Name="$(var.ThetisName) (UDP In)"
-                      Description="UDP In-bound Firewall rule for OpenHPSDR SDRs running Thetis"
-                      Protocol="udp"
-                      Scope="any"
-                      IgnoreFailure="no"
-                      Profile="all" />
-        </File>
+      <File Id="ThetisEXE"
+	    Source="$(var.FilesPath)Thetis.exe"
+	    KeyPath="yes">
+      </File>
       </Component>
-      
+
       <Component Guid="*">
         <File Id="CATStructsXML"
               Source="$(var.FilesPath)CATStructs.xml"


### PR DESCRIPTION
This pull request removes a firewall rule in the Thetis installer, which hinders compatibility with Wine (The Windows compatibility layer for Linux). When encountering this rule, which seems to open ports, Wine does not know how to handle it and bails the installer. 

Without this rule, the installation completes normally just like on Windows. I am not entirely sure what this rule does on Windows, so if the removal of this rule doesn't break anything on the Windows side, this PR should be merged.